### PR TITLE
Report external addresses to stdout

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -574,6 +574,11 @@ fn incoming_msg(addr: &mut LocalAddress, mut msg: &[u8]) -> Option<()> {
 				mapping.rt = rfc_6887::subsequent_rt(mapping.rt);
 				return None;
 			}
+		} else {
+			println!(
+				"Mapping was established, external address is [{}]:{}",
+				external_address, external_port
+			);
 		}
 
 		mapping.external_address = external_address;


### PR DESCRIPTION
This is especially important in NAT situations when the external address is certainly not the local address, and the port may be different.

Closes: https://github.com/ssiloti/portcontrolcd/issues/4